### PR TITLE
Fix Workers Build: remove [observability.traces]

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,14 +13,10 @@ binding = "ASSETS"
 [observability]
 enabled = true
 
+# Workers Logs. (Tracing — [observability.traces] — was removed: it's a beta
+# feature the deploy API rejected; re-enable it from the Cloudflare dashboard.)
 [observability.logs]
 enabled = true
-
-# Distributed (OpenTelemetry) tracing for the Worker. head_sampling_rate = 1
-# traces 100% of requests; lower it (e.g. 0.1) to reduce cost once traffic grows.
-[observability.traces]
-enabled = true
-head_sampling_rate = 1
 
 # Non-secret configuration. Secrets (OTP_PEPPER, TURN_API_TOKEN, carrier creds)
 # are set in the Cloudflare dashboard, NOT here.


### PR DESCRIPTION
The production Workers Build failed to deploy. Diagnosis:

- `npm ci` and bundling are fine; the build uses the same wrangler as a local `--dry-run`.
- The failure is at **deploy-time config validation** — which `--dry-run` skips. Runtime work (migrations, secrets) doesn't affect whether the deploy succeeds.
- The one new, risky thing this Worker adds over the previously-working prototype is **`[observability.traces]`**, a beta feature: it passes `wrangler deploy --dry-run` (client-side) but the deploy **API** rejects it unless the account is enrolled in tracing.

This PR removes only the `[observability.traces]` block. Logs/observability stay enabled; tracing can be re-enabled from the Cloudflare dashboard once available on the account.

**Purpose:** let the Cloudflare build run on this PR to confirm the deploy goes green. If it still fails, the build log will now show a different error and I'll fix that next.

Note: `ci.yml` (the GitHub Actions test workflow) contains **no secrets** and is unrelated to the Cloudflare build — nothing to change there.

https://claude.ai/code/session_01BCa21m2eJgVXQatcsoKN3y

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCa21m2eJgVXQatcsoKN3y)_