### PR TITLE
Enable Twilio PSTN calling (go live)

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,9 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 
 // E2E runs against a local `wrangler dev` with dev-only flags:
-//   EXPOSE_CODES=1     -> OTP codes are returned over HTTP so tests can read them
-//   TELEPHONY_ENABLED  -> exercise the (mock) dial path end-to-end
-// None of these are set in production.
+//   EXPOSE_CODES=1          -> OTP codes returned over HTTP so tests can read them
+//   TELEPHONY_ENABLED       -> exercise the dial path end-to-end
+//   TELEPHONY_PROVIDER=mock -> force the mock carrier, overriding wrangler.toml's
+//                              live "twilio" so the suite never hits the network
+// None of these override production.
 export default defineConfig({
   testDir: "./e2e",
   timeout: 45000,
@@ -25,7 +27,7 @@ export default defineConfig({
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
     command:
-      "npm run migrate:local && npx wrangler dev --port 8787 --var EXPOSE_CODES:1 --var OTP_PEPPER:e2e-pepper --var TELEPHONY_ENABLED:true",
+      "npm run migrate:local && npx wrangler dev --port 8787 --var EXPOSE_CODES:1 --var OTP_PEPPER:e2e-pepper --var TELEPHONY_ENABLED:true --var TELEPHONY_PROVIDER:mock",
     url: "http://localhost:8787",
     timeout: 120000,
     reuseExistingServer: !process.env.CI,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -19,6 +19,11 @@ export default defineConfig(async () => {
             OTP_PEPPER: "test-pepper",
             EXPOSE_CODES: "1",
             TEST_MIGRATIONS: migrations,
+            // Force the mock provider + kill-switch-off in tests, overriding
+            // wrangler.toml's live TELEPHONY_* values (tests must never hit the
+            // real carrier; individual tests opt in via { enabled: true }).
+            TELEPHONY_PROVIDER: "mock",
+            TELEPHONY_ENABLED: "false",
             // Test-only carrier creds so the webhook signature gate can be exercised.
             TWILIO_AUTH_TOKEN: "test-twilio-token",
           },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,17 +26,14 @@ head_sampling_rate = 1
 APP_ORIGIN = "https://calls.pierrefouquet.co.uk"
 EMAIL_FROM = "no-reply@pierrefouquet.co.uk"
 EMAIL_FROM_NAME = "Pierre Fouquet Calls"
-# External (PSTN) calling stays OFF until a carrier is deliberately wired in.
-TELEPHONY_ENABLED = "false"
-# Carrier selection. Left unset here (defaults to the mock, which the test suite
-# relies on). Production sets TELEPHONY_PROVIDER = "twilio" in the Cloudflare
-# dashboard, alongside the Twilio config below.
-#   Dashboard vars:    TELEPHONY_PROVIDER = "twilio"
-#                      TWILIO_ACCOUNT_SID, TWILIO_TWIML_APP_SID
-#   Dashboard secrets: TWILIO_AUTH_TOKEN       (REST auth + webhook signatures)
-#                      TWILIO_API_KEY_SID, TWILIO_API_KEY_SECRET  (Access Tokens)
-# The caller ID presented is the user's own mobile, validated via Twilio's
-# Verified Caller ID flow — no rented number required.
+# External (PSTN) calling via Twilio — LIVE. The kill-switch and provider live
+# here (committed) so they survive Workers Builds deploys. Twilio credentials are
+# dashboard secrets: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_API_KEY_SID,
+# TWILIO_API_KEY_SECRET, TWILIO_TWIML_APP_SID. Caller ID is the user's own mobile,
+# validated via Twilio's Verified Caller ID flow — no rented number. The test
+# suite forces the mock via vitest.config.js, so this never affects tests.
+TELEPHONY_ENABLED = "true"
+TELEPHONY_PROVIDER = "twilio"
 # Empty = call any country. Premium-rate/special numbers are blocked by line
 # type regardless. Set e.g. "+44,+33" to additionally restrict to countries.
 DEFAULT_ALLOWED_PREFIXES = ""
@@ -45,8 +42,9 @@ DEFAULT_ALLOWED_PREFIXES = ""
 #   DEFAULT_DAILY_SPEND_CAP_MICRO  block once a user's est. daily spend hits this
 # A per-user dial_policy row overrides both (daily_spend_cap_micro, per_call_max_sec).
 TELEPHONY_RATE_MICRO_PER_MIN = "20000"
-# DEFAULT_DAILY_SPEND_CAP_MICRO is left unset by default; set it in the dashboard
-# to enforce a tight cap (e.g. "200000" = ~20p/day) once telephony is live.
+# Tight daily spend-cap backstop (~£1/day). Blocks new dials once a user's
+# estimated daily spend reaches it; a per-user dial_policy row can override.
+DEFAULT_DAILY_SPEND_CAP_MICRO = "1000000"
 LOGIN_CODE_TTL_SECONDS = "600"
 SESSION_TTL_SECONDS = "2592000"
 


### PR DESCRIPTION
Flips external (PSTN) calling **live** via Twilio. The full integration already merged in #11; this PR just turns it on.

## What this changes
- `wrangler.toml`: `TELEPHONY_PROVIDER="twilio"`, `TELEPHONY_ENABLED="true"`, and a `DEFAULT_DAILY_SPEND_CAP_MICRO="1000000"` (~£1/day) toll-fraud backstop. Committed (not dashboard vars) so they survive Workers Builds deploys.
- `vitest.config.js`: pins `TELEPHONY_PROVIDER="mock"` + `TELEPHONY_ENABLED="false"` in the test env, so the suite never touches the real carrier.

## Prerequisites (done)
- ✅ 5 Twilio secrets set on the Worker: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_API_KEY_SID`, `TWILIO_API_KEY_SECRET`, `TWILIO_TWIML_APP_SID`.
- ✅ TwiML App created (Voice URL → `/api/voice/twiml`, POST; messaging blank).
- ✅ `0002_dial_tickets` migration applied to remote D1.

## On merge
Workers Builds deploys and PSTN goes live. No call is possible until a user validates their own mobile as caller ID (in-app: "My numbers" → add → key in Twilio's code).

## Safety
Caller-ID ownership, premium-rate blocks, hourly velocity cap (20), per-call time limit (1h), one-call-at-a-time, signature-verified webhooks, the `TELEPHONY_ENABLED` kill-switch, and the new ~£1/day spend cap. Adjust `DEFAULT_DAILY_SPEND_CAP_MICRO` here if £1/day is too tight/loose.

## Test after merge
Sign in → validate your mobile → dial a number → confirm two-way audio + caller ID, hang up, check call history. **Watch for:** if browser audio doesn't connect, the Twilio Voice SDK may need a small CSP tweak (audio-worklet `blob:`) — first place to look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)