### PR TITLE
Surface Twilio caller-ID validation errors instead of opaque 400

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -423,7 +423,11 @@ $("numbersList").addEventListener("click", async (e) => {
   if (action === "send") {
     const res = await api(`/api/numbers/${id}/verify`, { method: "POST" });
     if (!res.ok) {
-      setNumbersStatus(`Error: ${res.data.error || res.status}`);
+      // Carrier failures carry Twilio's own message + code so the reason is visible.
+      const detail = res.data.detail
+        ? `${res.data.detail}${res.data.providerCode ? ` (Twilio ${res.data.providerCode})` : ""}`
+        : res.data.error || res.status;
+      setNumbersStatus(`Error: ${detail}`);
     } else if (res.data.displayCode) {
       // Carrier-driven validation (Twilio): the carrier calls the number and the
       // user keys in this code on their handset, then clicks Confirm.

--- a/src/lib/numbers.js
+++ b/src/lib/numbers.js
@@ -95,7 +95,14 @@ export async function sendNumberVerification(env, userId, numberId, channelOverr
       friendlyName: `user:${userId}`,
       statusCallbackUrl: statusCb,
     });
-    if (!res.ok) return { ok: false, error: "provider_error" };
+    if (!res.ok) {
+      console.warn("startCallerIdValidation failed", {
+        status: res.status,
+        code: res.code,
+        detail: res.detail,
+      });
+      return { ok: false, error: "provider_error", status: res.status, code: res.code, detail: res.detail };
+    }
     await env.DB.prepare(
       "UPDATE verified_numbers SET channel = 'voice', provider_ref = ?, verify_attempts = 0 WHERE id = ?"
     )

--- a/src/lib/telephony/twilio.js
+++ b/src/lib/telephony/twilio.js
@@ -90,7 +90,16 @@ export class TwilioProvider {
     if (friendlyName) form.FriendlyName = friendlyName;
     if (statusCallbackUrl) form.StatusCallback = statusCallbackUrl;
     const r = await this.rest("POST", "/OutgoingCallerIds.json", form);
-    if (!r.ok || !r.data) return { ok: false, status: r.status };
+    if (!r.ok || !r.data || !r.data.validation_code) {
+      // Surface Twilio's own error so callers can diagnose (21215 geo-perm,
+      // 21421 invalid number, 20003 auth, etc.) instead of a blind failure.
+      return {
+        ok: false,
+        status: r.status,
+        code: r.data && r.data.code,
+        detail: (r.data && r.data.message) || null,
+      };
+    }
     return { ok: true, displayCode: r.data.validation_code, ref: r.data.call_sid };
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,6 +4,7 @@
 
 import { parseCookies, serializeCookie, SESSION_COOKIE, CSRF_COOKIE } from "./lib/cookies.js";
 import {
+  json,
   ok,
   badRequest,
   unauthorized,
@@ -279,6 +280,13 @@ async function hSendVerify(request, env, c) {
   if (!r.ok) {
     if (r.error === "rate_limited") return tooManyRequests();
     if (r.error === "not_found") return notFound();
+    if (r.error === "provider_error") {
+      console.warn("number verification provider error", { status: r.status, code: r.code, detail: r.detail });
+      return json(
+        { ok: false, error: "provider_error", providerStatus: r.status, providerCode: r.code, detail: r.detail },
+        400
+      );
+    }
     return badRequest(r.error);
   }
   // The OTP is delivered by the carrier; only exposed over HTTP in dev/test.

--- a/test/twilio-callerid.test.js
+++ b/test/twilio-callerid.test.js
@@ -48,6 +48,23 @@ describe("twilio verified caller id — provider", () => {
     expect(r).toMatchObject({ ok: true, displayCode: "482913", ref: "CA123" });
   });
 
+  it("startCallerIdValidation surfaces Twilio's error code and message on failure", async () => {
+    stubTwilio({
+      [`POST ${base}`]: {
+        status: 400,
+        body: { code: 21215, message: "Account not authorized to call +447400123456" },
+      },
+    });
+    const p = new TwilioProvider(fakeEnv());
+    const r = await p.startCallerIdValidation({ e164: "+447400123456" });
+    expect(r).toMatchObject({
+      ok: false,
+      status: 400,
+      code: 21215,
+      detail: "Account not authorized to call +447400123456",
+    });
+  });
+
   it("isCallerIdValidated reflects whether the number is on the account", async () => {
     const e164 = "+447400123456";
     stubTwilio({ [listKey(e164)]: { status: 200, body: { outgoing_caller_ids: [{ phone_number: e164 }] } } });


### PR DESCRIPTION
## Why
Verifying a number (the **Send code** button) hit a `400 Bad Request` from `/api/numbers/:id/verify`, and the user's phone never rang. The 400 was the worker's generic `provider_error` — `startCallerIdValidation` discarded Twilio's response body (`{ code, message }`), so the real cause was undiagnosable and the validation call was never placed.

## What
Thread Twilio's `status` / `code` / `message` through the chain so the actual reason is visible:
- `twilio.js` — `startCallerIdValidation` returns Twilio's status/code/detail on failure (also treats a missing `validation_code` as a failure).
- `numbers.js` — `sendNumberVerification` propagates them and `console.warn`s.
- `worker.js` — the `/verify` 400 now carries `providerStatus`, `providerCode`, `detail`.
- `script.js` — the UI prints Twilio's message + code instead of "Error: provider_error".
- Added a test for the failure path.

## Not a behaviour change to the happy path
Successful validation is unchanged; this only makes failures legible. The likely production causes to check next (now visible in the UI / `wrangler tail` / Twilio Debugger): `20003` auth (`TWILIO_AUTH_TOKEN` secret), `21215` geo-permissions for `+44`, `21421/21450` bad number.

## Test
`npx vitest run` — 69 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)